### PR TITLE
(feat) Add shared-model demo.

### DIFF
--- a/demo/shared-model.demo.html
+++ b/demo/shared-model.demo.html
@@ -1,0 +1,4 @@
+<script src="../bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+<link rel="import" href="./shared-model.html">
+
+<host-element></host-element>

--- a/demo/shared-model.html
+++ b/demo/shared-model.html
@@ -1,0 +1,78 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<dom-module id="host-element">
+  <template>
+    <p>in host element</p>
+    <model-element id="modelElement" model="{{hostModel}}"></model-element>
+  </template>
+
+  <script>
+    HTMLImports.whenReady(() => {
+      class HostElement extends Polymer.Element {
+        static get is() { return "host-element" }
+
+        static get properties() {
+          return {
+            hostModel: Object
+          }
+        }
+
+        static get observers() {
+          return [
+            "_onHostModelChanged(hostModel.*)",
+          ]
+        }
+
+        ready() {
+          super.ready()
+          console.log("host-element ready:", this)
+
+          this.set("hostModel", { change: 1 })
+          this.$.modelElement.set("model", { change: 2 })
+          this.set("hostModel.change", 3)
+
+          // change without notification in model. the hostModel was changed, too.
+          // conclusion: model and hostModel refer to the same object.
+          this.$.modelElement.model.change = 4
+          console.log(this.$.modelElement.model, this.hostModel)
+          console.log(this.$.modelElement.model === this.hostModel)
+        }
+
+        _onHostModelChanged(event) {
+          console.log("host model changed", this.hostModel, "event:", event.path, event.value)
+        }
+      }
+
+      window.customElements.define(HostElement.is, HostElement)
+    })
+  </script>
+</dom-module>
+
+<dom-module id="model-element">
+  <template>
+    <p>in model element</p>
+  </template>
+
+  <script>
+    class ModelElement extends Polymer.Element {
+      static get is() { return "model-element" }
+
+      static get properties() {
+        return {
+          model: {
+            type: Object,
+            value: () => { return { change: 0 } },
+            notify: true
+          }
+        }
+      }
+
+      ready() {
+        super.ready()
+        console.log("model-element ready:", this)
+      }
+    }
+
+    window.customElements.define(ModelElement.is, ModelElement)
+  </script>
+</dom-module>

--- a/demo/shared-model.html
+++ b/demo/shared-model.html
@@ -3,7 +3,7 @@
 <dom-module id="host-element">
   <template>
     <p>in host element</p>
-    <model-element id="modelElement" model="{{hostModel}}"></model-element>
+    <data-element id="dataElement" model="{{hostModel}}"></data-element>
   </template>
 
   <script>
@@ -28,14 +28,14 @@
           console.log("host-element ready:", this)
 
           this.set("hostModel", { change: 1 })
-          this.$.modelElement.set("model", { change: 2 })
+          this.$.dataElement.set("model", { change: 2 })
           this.set("hostModel.change", 3)
 
           // change without notification in model. the hostModel was changed, too.
           // conclusion: model and hostModel refer to the same object.
-          this.$.modelElement.model.change = 4
-          console.log(this.$.modelElement.model, this.hostModel)
-          console.log(this.$.modelElement.model === this.hostModel)
+          this.$.dataElement.model.change = 4
+          console.log(this.$.dataElement.model, this.hostModel)
+          console.log(this.$.dataElement.model === this.hostModel)
         }
 
         _onHostModelChanged(event) {
@@ -48,14 +48,14 @@
   </script>
 </dom-module>
 
-<dom-module id="model-element">
+<dom-module id="data-element">
   <template>
-    <p>in model element</p>
+    <p>in data element</p>
   </template>
 
   <script>
-    class ModelElement extends Polymer.Element {
-      static get is() { return "model-element" }
+    class DataElement extends Polymer.Element {
+      static get is() { return "data-element" }
 
       static get properties() {
         return {
@@ -69,10 +69,10 @@
 
       ready() {
         super.ready()
-        console.log("model-element ready:", this)
+        console.log("data-element ready:", this)
       }
     }
 
-    window.customElements.define(ModelElement.is, ModelElement)
+    window.customElements.define(DataElement.is, DataElement)
   </script>
 </dom-module>


### PR DESCRIPTION
This demo implements two custom elements: `<host-element>` (with `hostModel` property) and `<data-element>` (with `model` property).

It shows the following:
1. The host element can contain a data element in it's template.
2. The host element can bind the data element's `model` property to its `hostModel` property.
3. The host element can observe changes to the `model` through its `hostModel`.
4. Both `model` and `hostModel` refer to the same object instance.

~~~html
<dom-module id="host-element">
  <template>
    <p>in host element</p>
    <data-element id="dataElement" model="{{hostModel}}"></data-element>
  </template>

  <script>
    class HostElement extends Polymer.Element {
      // ...
    }
    window.customElements.define(HostElement.is, HostElement)
  </script>
</dom-module>
~~~